### PR TITLE
Extend timeout for custom_generate endpoint to 60s

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "api/custom_generate/**": {
+    "app/api/custom_generate/**": {
       "maxDuration": 60
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/custom_generate/**": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
Related to #1

Adds a configuration to prevent the `custom_generate` API endpoint from timing out before 60 seconds when hosted in Vercel.
- **Configuration Update**: Introduces a `vercel.json` file with a `functions` property that specifies a 60-second `maxDuration` for the `api/custom_generate` endpoint, addressing the issue of premature timeouts during longer song generation tasks.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jonico/suno-api/issues/1?shareId=6a9c4abe-e535-4567-b022-af49ae20b200).