### PR TITLE
Add Postman collection for generating pop songs

### DIFF
--- a/postman/SunoAPI-GeneratePopSong.postman_collection.json
+++ b/postman/SunoAPI-GeneratePopSong.postman_collection.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "name": "SunoAPI-GeneratePopSong",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Generate Pop Song",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"prompt\": \"Create a beautiful pop song about automated code generation\",\n  \"tags\": \"pop, upbeat, happy\",\n  \"title\": \"The Code Generation Song\",\n  \"make_instrumental\": false,\n  \"wait_audio\": true\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{url}}/api/custom_generate",
+          "host": [
+            "{{url}}"
+          ],
+          "path": [
+            "api",
+            "custom_generate"
+          ]
+        }
+      },
+      "response": [],
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"API call completes within 60 seconds\", function () {",
+              "    pm.expect(pm.response.responseTime).to.be.below(60000);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "pm.visualizer.set(\"<h2>Generated Pop Song Links</h2><ul>{{responseBody.audio_files.map(file => `<li><a href='${file}'>${file}</a></li>`).join('')}}</ul>\", {responseBody: pm.response.json()});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Related to #3

Adds a new Postman collection to generate a pop song about automated code generation using the `custom_generate` API endpoint.
- **Request Configuration**: Configures a POST request with parameters for generating a pop song, including the prompt, tags, title, and audio settings.
- **Test Script**: Includes a test script to ensure the API call completes within 60 seconds.
- **Visualization Script**: Implements a visualization script for displaying generated audio file links in the Postman Visualizer, enhancing the user experience by providing direct access to the generated content.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jonico/suno-api/issues/3?shareId=a0c93eca-b651-41c9-a591-2c7ac2b699af).